### PR TITLE
Update link to OSCP exam guide and add online reverse shell generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ### OSCP Reviews and Guides
 
-- [Official OSCP Certification Exam Guide](https://support.offensive-security.com/oscp-exam-guide/)
+- [Official OSCP Certification Exam Guide](https://help.offensive-security.com/hc/en-us/articles/360040165632-OSCP-Exam-Guide)
 - Luke’s Ultimate OSCP Guide ([Part 1](https://medium.com/@hakluke/haklukes-ultimate-oscp-guide-part-1-is-oscp-for-you-b57cbcce7440), [Part 2](https://medium.com/@hakluke/haklukes-ultimate-oscp-guide-part-2-workflow-and-documentation-tips-9dd335204a48), [Part 3](https://medium.com/@hakluke/haklukes-ultimate-oscp-guide-part-3-practical-hacking-tips-and-tricks-c38486f5fc97))
 - [How to prepare for PWK/OSCP, a noob-friendly guide](https://www.abatchy.com/2017/03/how-to-prepare-for-pwkoscp-noob)
 - [n3ko1's OSCP Guide](http://www.lucas-bader.com/certification/2015/05/27/oscp-offensive-security-certified-professional)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [Penetration Testing Tools Cheat Sheet](https://highon.coffee/blog/penetration-testing-tools-cheat-sheet/)
 - [How to Pass OSCP](https://gist.github.com/unfo/5ddc85671dcf39f877aaf5dce105fac3)
 - [Reverse Shell Cheat Sheet](https://highon.coffee/blog/reverse-shell-cheat-sheet/)
+- [Reverse Shell Generator](https://www.revshells.com/)
 - [7 Linux Shells Using Built-in Tools](https://www.lanmaster53.com/2011/05/7-linux-shells-using-built-in-tools/)
 - [Windows Exploit Suggester](https://github.com/GDSSecurity/Windows-Exploit-Suggester)
 - [Linux Exploit Suggester](https://github.com/InteliSecureLabs/Linux_Exploit_Suggester)


### PR DESCRIPTION
- Updated link to official OSCP exam guide; the old link was redirecting to a generic page containing all exams
- Added a very cool website which generates reverse shell commands for various tools